### PR TITLE
Remove incorrect quote from APIO install instructions

### DIFF
--- a/bx/guide.md
+++ b/bx/guide.md
@@ -35,7 +35,7 @@ Most Linux distributions install Python by default.  If not, install Python usin
 To install APIO and tinyprog, open up a terminal and run the following commands:
 
 ```shell
-pip install apio==0.4.0b3 tinyprog"
+pip install apio==0.4.0b3 tinyprog
 apio install system scons icestorm iverilog
 apio drivers --serial-enable
 ```


### PR DESCRIPTION
This quote is not part of the command, and can be confusing when
copying the instructions. It also causes the shell markup to start
formatting the following commands as a string. Remove the unneeded
character.