### PR TITLE
Update Apio to beta 5 to fix "Atom. Error: board TinyFPGA-BX not available"

### DIFF
--- a/bx/guide.md
+++ b/bx/guide.md
@@ -35,7 +35,7 @@ Most Linux distributions install Python by default.  If not, install Python usin
 To install APIO and tinyprog, open up a terminal and run the following commands:
 
 ```shell
-pip install apio==0.4.0b3 tinyprog
+pip install apio==0.4.0b5 tinyprog
 apio install system scons icestorm iverilog
 apio drivers --serial-enable
 ```


### PR DESCRIPTION

Fixes the issue reported in:
https://discourse.tinyfpga.com/t/atom-error-board-tinyfpga-bx-not-available/528