### PR TITLE
Add missing apio package `drivers` to bx guide

### DIFF
--- a/bx/guide.md
+++ b/bx/guide.md
@@ -36,7 +36,7 @@ To install APIO and tinyprog, open up a terminal and run the following commands:
 
 ```shell
 pip install apio==0.4.0b5 tinyprog
-apio install system scons icestorm iverilog
+apio install system scons icestorm iverilog drivers
 apio drivers --serial-enable
 ```
 


### PR DESCRIPTION
While following the instructions here, I couldn't run `apio drivers --serial-enable` before installing the `drivers` package.

Running on Windows 10, Python 3.7.4 installed from the Microsoft Store